### PR TITLE
Make cx, cy default to 0

### DIFF
--- a/glsvg/svg_path_builder.py
+++ b/glsvg/svg_path_builder.py
@@ -108,8 +108,8 @@ class SVGPathBuilder(object):
             self.end_path()
         elif e.tag.endswith('circle'):
             self.shape = path.shape = 'circle'
-            cx = float(e.get('cx'))
-            cy = float(e.get('cy'))
+            cx = float(e.get('cx', '0'))
+            cy = float(e.get('cy', '0'))
             r = float(e.get('r'))
             path.cx, path.cy, path.r = cx, cy, r
             for i in xrange(config.circle_points):
@@ -119,8 +119,8 @@ class SVGPathBuilder(object):
             self.end_path()
         elif e.tag.endswith('ellipse'):
             self.shape = path.shape = 'ellipse'
-            cx = float(e.get('cx'))
-            cy = float(e.get('cy'))
+            cx = float(e.get('cx', '0'))
+            cy = float(e.get('cy', '0'))
             rx = float(e.get('rx'))
             ry = float(e.get('ry'))
             path.cx, path.cy, path.rx, path.ry = cx, cy, rx, ry
@@ -438,6 +438,5 @@ class SVGPathBuilder(object):
 
     def _warn(self, message):
         print "Warning: SVG Parser - %s" % (message,)
-
 
 


### PR DESCRIPTION
Fixed to match the spec at

https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/cx

https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/cy

Means it can load the wikipedia smiley, though rendering is not correct yet

There are some things that don't display yet:

http://imgur.com/BWa5G3G

The right eye - this seems to be the 'use' tag not working.the gradient effect seems to be 'radialGradient' which is not implemented yet.


```xml
<?xml version="1.0" standalone="no"?>
<!DOCTYPE svg>
<svg version="1.1" baseProfile="full" xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid meet" zoomAndPan="magnify"
   id="Test File"
   viewBox="-21 -21 42 42"
   width="800"
   height="800">

<defs>
<radialGradient id="shine"
      cx=".2" cy=".2" r=".5" fx=".2" fy=".2">
  <stop offset="0" stop-color="white" stop-opacity=".7"/>
  <stop offset="1" stop-color="white" stop-opacity="0"/>
</radialGradient>
<radialGradient id="grad"
      cx=".5" cy=".5" r=".5" >
  <stop offset="0" stop-color="yellow"/>
  <stop offset=".75" stop-color="yellow"/>
  <stop offset=".95" stop-color="#ee0"/>
  <stop offset="1" stop-color="#e8e800"/>
</radialGradient>
  
</defs>

<circle r="20" stroke="black" stroke-width=".15" fill="url(#grad)"/>
<circle r="20" fill="url(#shine)"/>
<g id="right">
  <ellipse rx="2.5" ry="4" cx="-6" cy="-7" fill="black"/>
  <path fill="none" stroke="black" stroke-width=".5" stroke-linecap="round" d="M 10.6,2.7 a 4,4,0 0,0 4,3"/>
</g>
<use xlink:href="#right" transform="scale(-1,1)"/>
<path fill="none" stroke="black" stroke-width=".75" d="M -12,5 A 13.5,13.5,0 0,0 12,5 A 13,13,0 0,1 -12,5"/>
</svg>
```