### PR TITLE
Optionally use setuptools, so that setup.py develop can work

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,7 @@
-
-from distutils.core import setup
+try:
+    from setuptools import setup
+except ImportError:
+    from distutils.core import setup
 setup(
     name = "glsvg",
     packages = ["glsvg"],


### PR DESCRIPTION
using  setup.py develop  can make things a bit more convenient during developement instead of setup.py install